### PR TITLE
Add Qwen2.5-VL model wrapper

### DIFF
--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -43,6 +43,7 @@ AVAILABLE_MODELS = {
     "xcomposer2_4KHD": "XComposer2_4KHD",
     "xcomposer2d5": "XComposer2D5",
     "qwen2vl": "Qwen2VL",
+    "qwen25vl": "Qwen25VL",
     "qwen3vl": "Qwen3VL",
 }
 

--- a/lmms_eval/models/qwen25vl.py
+++ b/lmms_eval/models/qwen25vl.py
@@ -1,0 +1,25 @@
+"""Thin wrapper for evaluating Qwen2.5-VL models via the Qwen3VL implementation."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, Union
+
+from lmms_eval.api.registry import register_model
+
+from .qwen3vl import Qwen3VL
+
+
+@register_model("qwen25vl")
+class Qwen25VL(Qwen3VL):
+    """Expose Qwen/Qwen2.5-VL checkpoints using the Qwen3VL backend."""
+
+    def __init__(
+        self,
+        pretrained: str = "Qwen/Qwen2.5-VL-7B-Instruct",
+        repo_root: Optional[Union[str, os.PathLike]] = None,
+        **kwargs: Any,
+    ) -> None:
+        kwargs.setdefault("repo_env_var", "QWEN25_VL_REPO")
+        kwargs.setdefault("repo_default", "Qwen2.5-VL")
+        super().__init__(pretrained=pretrained, repo_root=repo_root, **kwargs)


### PR DESCRIPTION
## Summary
- add a thin Qwen25VL wrapper that reuses the Qwen3VL implementation for Qwen/Qwen2.5-VL-7B-Instruct
- generalize repository resolution in Qwen3VL so different Qwen repositories can be configured
- register the new wrapper in the model registry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905c1af2b5c832d8618d06a5a7b1ca5